### PR TITLE
Add FastAPI backend and wire frontend to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,57 @@
-# d-ch-v-mua-s-m-
+# NovaWave Commerce
+
+NovaWave là trải nghiệm thương mại điện tử kết hợp giao diện neon tương lai với backend Python sử dụng FastAPI và cơ sở dữ liệu SQLite. Dự án minh họa cách kết nối liền mạch giữa frontend tĩnh và API backend cho các luồng đăng ký/đăng nhập, quản lý sản phẩm, giỏ hàng và thanh toán.
+
+## Kiến trúc
+
+- **Frontend**: HTML/CSS/JavaScript thuần, cung cấp trải nghiệm thị giác động và tương tác.
+- **Backend**: FastAPI chạy bằng Python, lưu trữ dữ liệu trong SQLite (`backend/novawave.db`).
+- **API chính**:
+  - `POST /api/auth/register` & `POST /api/auth/login`: xác thực người dùng, trả về token phiên.
+  - `GET/POST/PUT/DELETE /api/products`: quản trị viên quản lý danh mục sản phẩm.
+  - `POST /api/orders`: tạo đơn hàng với nhiều phương thức thanh toán.
+  - `GET /api/orders`: lịch sử đơn hàng theo người dùng hoặc toàn hệ thống (admin).
+  - `GET /api/settings` và `PUT /api/settings/*`: lưu cấu hình giao diện & thanh toán trong cơ sở dữ liệu.
+
+## Cài đặt & chạy dự án
+
+1. **Tạo virtualenv và cài đặt backend**
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate  # Windows dùng .venv\Scripts\activate
+   pip install -r requirements.txt
+   ```
+
+2. **Chạy API FastAPI**
+   ```bash
+   uvicorn backend.app:app --reload
+   ```
+   API sẽ lắng nghe tại `http://localhost:8000`.
+
+3. **Phục vụ frontend**
+   Trong một terminal khác tại thư mục gốc dự án:
+   ```bash
+   python -m http.server 5500
+   ```
+   Truy cập `http://localhost:5500/index.html` trong trình duyệt. Ứng dụng sẽ tự động kết nối tới API tại `http://localhost:8000/api`.
+
+## Tài khoản mặc định
+
+- **Quản trị viên**: `admin@novawave.vn` / `admin123`
+  - Có thể chỉnh sửa sản phẩm, thay đổi cài đặt giao diện và quản lý thông điệp thanh toán.
+
+## Tùy chỉnh
+
+- Để đổi khóa đăng ký admin, cập nhật hằng số `ADMIN_ENROLL_KEY` trong `backend/app.py`.
+- Dữ liệu mẫu sản phẩm được khởi tạo trong hàm `seed_products` và có thể chỉnh sửa để phù hợp nhu cầu.
+
+## Kiểm thử nhanh
+
+- Đăng ký người dùng mới, đăng nhập và thêm sản phẩm vào giỏ hàng.
+- Dùng tài khoản admin để tạo/ cập nhật sản phẩm, bật/tắt các hiệu ứng hiển thị và thay đổi thông điệp thanh toán.
+- Hoàn tất thanh toán để xem đơn hàng được lưu vào lịch sử và bảng điều khiển.
+
+## Giấy phép
+
+Dự án dùng cho mục đích minh họa. Tùy ý mở rộng và tái sử dụng.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,970 @@
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at top, #040b1a, #02030a 60%);
+  --glass: rgba(12, 20, 40, 0.7);
+  --glass-strong: rgba(30, 45, 80, 0.75);
+  --accent: #5cf1ff;
+  --accent-2: #d67bff;
+  --accent-3: #19ffb5;
+  --text: #f5f8ff;
+  --muted: #8b9dc7;
+  --danger: #ff7b9c;
+  font-size: clamp(15px, 0.95vw + 12px, 18px);
+  font-family: "Rubik", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(115deg, rgba(92, 241, 255, 0.1), rgba(214, 123, 255, 0.06));
+  pointer-events: none;
+  z-index: -1;
+}
+
+.neon-grid {
+  position: fixed;
+  inset: 0;
+  background-image: linear-gradient(rgba(92, 241, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(214, 123, 255, 0.05) 1px, transparent 1px);
+  background-size: 80px 80px;
+  mask-image: radial-gradient(circle at center, rgba(255, 255, 255, 0.8), transparent 80%);
+  z-index: -1;
+  animation: pulse 12s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.9;
+    transform: scale(1.03);
+  }
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.25rem clamp(1.5rem, 3vw, 3rem);
+  backdrop-filter: blur(16px);
+  background: linear-gradient(115deg, rgba(12, 20, 40, 0.6), rgba(12, 20, 40, 0.1));
+  border-bottom: 1px solid rgba(92, 241, 255, 0.12);
+  z-index: 10;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.logo-icon {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(92, 241, 255, 0.4), rgba(214, 123, 255, 0.2));
+  box-shadow: 0 0 24px rgba(92, 241, 255, 0.4);
+  animation: float 6s ease-in-out infinite;
+}
+
+.logo h1 {
+  font-family: "Orbitron", sans-serif;
+  letter-spacing: 0.08em;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  margin: 0;
+}
+
+.logo p {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+nav {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.nav-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--muted);
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.nav-btn.active,
+.nav-btn:hover {
+  color: var(--text);
+  border-color: rgba(92, 241, 255, 0.5);
+  background: linear-gradient(135deg, rgba(92, 241, 255, 0.12), rgba(214, 123, 255, 0.1));
+  box-shadow: 0 8px 24px rgba(92, 241, 255, 0.25);
+}
+
+.auth-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.primary-btn,
+.ghost-btn {
+  font: inherit;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  cursor: pointer;
+  transition: transform 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
+}
+
+.primary-btn {
+  color: #03050c;
+  background: linear-gradient(120deg, #5cf1ff, #d67bff);
+  border: none;
+  box-shadow: 0 12px 24px rgba(92, 241, 255, 0.35);
+}
+
+.primary-btn:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 18px 36px rgba(92, 241, 255, 0.45);
+}
+
+.ghost-btn {
+  background: rgba(92, 241, 255, 0.08);
+  border: 1px solid rgba(92, 241, 255, 0.2);
+  color: var(--text);
+}
+
+.ghost-btn:hover {
+  transform: translateY(-1px);
+  background: rgba(92, 241, 255, 0.15);
+}
+
+.cart-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  background: rgba(92, 241, 255, 0.08);
+  border: 1px solid rgba(92, 241, 255, 0.2);
+  color: var(--text);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.cart-btn::after {
+  content: attr(data-count);
+  position: absolute;
+  top: -0.4rem;
+  right: -0.4rem;
+  background: linear-gradient(135deg, #ff9fd3, #d67bff);
+  color: #0a0314;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-size: 0.75rem;
+  box-shadow: 0 0 12px rgba(214, 123, 255, 0.55);
+}
+
+.cart-btn:hover {
+  transform: translateY(-1px) scale(1.02);
+  background: rgba(92, 241, 255, 0.16);
+}
+
+.user-pill {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(92, 241, 255, 0.12);
+  border: 1px solid rgba(92, 241, 255, 0.2);
+  box-shadow: inset 0 0 12px rgba(92, 241, 255, 0.2);
+}
+
+main {
+  padding: 2rem clamp(1.5rem, 3vw, 3rem) 4rem;
+  display: grid;
+  gap: 3rem;
+}
+
+.view {
+  display: none;
+  animation: fade-in 0.6s ease forwards;
+}
+
+.view.active {
+  display: block;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+  gap: clamp(2rem, 4vw, 4rem);
+  padding: clamp(2rem, 5vw, 4rem);
+  background: linear-gradient(140deg, rgba(12, 20, 40, 0.7), rgba(12, 20, 40, 0.4));
+  border-radius: 2.5rem;
+  border: 1px solid rgba(92, 241, 255, 0.18);
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.45);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(214, 123, 255, 0.2), transparent 60%);
+  pointer-events: none;
+}
+
+.hero-content h2 {
+  font-family: "Orbitron", sans-serif;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  letter-spacing: 0.12em;
+  margin: 0 0 1rem;
+}
+
+.hero-content p {
+  color: var(--muted);
+  line-height: 1.8;
+  margin-bottom: 1.8rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.live-stats {
+  margin-top: 2rem;
+  display: grid;
+  gap: 0.8rem;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.hero-visual {
+  position: relative;
+  height: 320px;
+}
+
+.sphere,
+.ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+}
+
+.sphere {
+  background: radial-gradient(circle at 30% 30%, rgba(92, 241, 255, 0.45), rgba(12, 20, 40, 0.2));
+  filter: drop-shadow(0 0 24px rgba(92, 241, 255, 0.4));
+  animation: float 8s ease-in-out infinite;
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(0, -18px, 0) scale(1.02);
+  }
+}
+
+.ring {
+  border: 1px solid rgba(214, 123, 255, 0.4);
+  animation: spin 14s linear infinite;
+  box-shadow: 0 0 32px rgba(214, 123, 255, 0.25);
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg) scale(1.05);
+  }
+  to {
+    transform: rotate(360deg) scale(1.05);
+  }
+}
+
+.orbiting-card {
+  position: absolute;
+  top: 20%;
+  right: 15%;
+  width: 200px;
+  height: 200px;
+  border-radius: 1.5rem;
+  background: linear-gradient(145deg, rgba(92, 241, 255, 0.3), rgba(214, 123, 255, 0.25));
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(92, 241, 255, 0.35);
+  box-shadow: 0 24px 80px rgba(92, 241, 255, 0.4);
+  animation: orbit 12s ease-in-out infinite;
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+@keyframes orbit {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+  50% {
+    transform: translate3d(-30px, 30px, 0);
+  }
+}
+
+.orbiting-card h5 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.orbiting-card p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+.section-title {
+  font-family: "Orbitron", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.categories {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.category-card {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(92, 241, 255, 0.18);
+  background: linear-gradient(160deg, rgba(12, 20, 40, 0.6), rgba(12, 20, 40, 0.4));
+  overflow: hidden;
+  transition: transform 0.45s ease, box-shadow 0.45s ease;
+  cursor: pointer;
+}
+
+.category-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(92, 241, 255, 0.2), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+
+.category-card:hover {
+  transform: translate3d(0, -12px, 0) scale(1.02);
+  box-shadow: 0 28px 60px rgba(92, 241, 255, 0.2);
+}
+
+.category-card:hover::after {
+  opacity: 1;
+}
+
+.category-card h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.category-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+select,
+input[type="search"],
+input[type="text"],
+input[type="number"],
+input[type="url"],
+input[type="email"],
+input[type="password"],
+textarea {
+  background: rgba(12, 20, 40, 0.85);
+  border: 1px solid rgba(92, 241, 255, 0.25);
+  border-radius: 0.9rem;
+  padding: 0.65rem 0.9rem;
+  color: var(--text);
+  font: inherit;
+  transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+select:focus,
+input:focus,
+textarea:focus {
+  border-color: rgba(92, 241, 255, 0.55);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(92, 241, 255, 0.18);
+}
+
+.product-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.product-card {
+  position: relative;
+  padding: 1.5rem;
+  border-radius: 1.8rem;
+  background: linear-gradient(165deg, rgba(12, 20, 40, 0.75), rgba(12, 20, 40, 0.5));
+  border: 1px solid rgba(92, 241, 255, 0.16);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+  display: grid;
+  gap: 1rem;
+  transition: transform 0.45s ease, box-shadow 0.45s ease;
+}
+
+.product-card .glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(92, 241, 255, 0.25), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+}
+
+.product-card:hover {
+  transform: translate3d(0, -16px, 0);
+  box-shadow: 0 32px 80px rgba(92, 241, 255, 0.35);
+}
+
+.product-card:hover .glow {
+  opacity: 1;
+}
+
+.product-image {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  border-radius: 1.2rem;
+}
+
+.product-body {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.product-title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.product-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.product-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.product-category {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  color: rgba(92, 241, 255, 0.8);
+}
+
+.product-price {
+  font-size: 1.15rem;
+  background: linear-gradient(120deg, #5cf1ff, #19ffb5);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.product-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.product-actions button {
+  flex: 1;
+}
+
+.cart-drawer {
+  position: fixed;
+  top: 0;
+  right: -460px;
+  width: min(420px, 100vw);
+  height: 100vh;
+  background: rgba(12, 20, 40, 0.94);
+  border-left: 1px solid rgba(92, 241, 255, 0.24);
+  box-shadow: -12px 0 40px rgba(0, 0, 0, 0.45);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  transform: translateX(0);
+  z-index: 20;
+}
+
+.cart-drawer.open {
+  transform: translateX(-460px);
+}
+
+.cart-header,
+.cart-summary {
+  padding: 1.5rem;
+  border-bottom: 1px solid rgba(92, 241, 255, 0.18);
+}
+
+.cart-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cart-items {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.cart-item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(12, 20, 40, 0.6);
+  border: 1px solid rgba(92, 241, 255, 0.12);
+}
+
+.item-info h4 {
+  margin: 0;
+}
+
+.item-info p {
+  margin: 0.2rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.item-controls {
+  display: inline-flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.item-price {
+  font-weight: 600;
+}
+
+.summary-line {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+  color: var(--muted);
+}
+
+.summary-line.total {
+  font-size: 1.1rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.payment-options {
+  margin: 1.5rem 0;
+}
+
+.payment-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.payment-grid label {
+  padding: 0.75rem;
+  background: rgba(92, 241, 255, 0.1);
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  transition: border 0.3s ease, background 0.3s ease;
+  cursor: pointer;
+}
+
+.payment-grid label:hover {
+  border-color: rgba(92, 241, 255, 0.4);
+}
+
+.security-note {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-top: 1rem;
+}
+
+.auth-modal::backdrop {
+  backdrop-filter: blur(20px);
+  background: rgba(2, 4, 12, 0.75);
+}
+
+.auth-shell {
+  width: min(420px, 90vw);
+  padding: 1.8rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(155deg, rgba(12, 20, 40, 0.95), rgba(12, 20, 40, 0.75));
+  border: 1px solid rgba(92, 241, 255, 0.25);
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.45);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.auth-shell header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.register-only {
+  display: none;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.auth-message {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--danger);
+  min-height: 1.2rem;
+}
+
+.view.active .order-timeline {
+  animation: wave 1.2s ease;
+}
+
+@keyframes wave {
+  from {
+    transform: translateX(24px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+.orders-wrapper {
+  padding: 2rem;
+  border-radius: 2rem;
+  background: linear-gradient(160deg, rgba(12, 20, 40, 0.8), rgba(12, 20, 40, 0.5));
+  border: 1px solid rgba(92, 241, 255, 0.14);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.45);
+}
+
+.order-entry {
+  border-left: 2px solid rgba(92, 241, 255, 0.4);
+  margin-left: 0.6rem;
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
+  position: relative;
+}
+
+.order-entry::before {
+  content: "";
+  position: absolute;
+  left: -1.5rem;
+  top: 0.5rem;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  background: linear-gradient(120deg, #5cf1ff, #d67bff);
+  box-shadow: 0 0 16px rgba(92, 241, 255, 0.6);
+}
+
+.order-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.order-body {
+  margin: 0.75rem 0;
+  color: var(--muted);
+}
+
+.order-customer {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(92, 241, 255, 0.12);
+  color: var(--text);
+  letter-spacing: 0.01em;
+}
+
+.order-footer {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.admin-panel {
+  display: grid;
+  gap: 2rem;
+  padding: 2.5rem;
+  border-radius: 2.5rem;
+  background: linear-gradient(155deg, rgba(12, 20, 40, 0.8), rgba(12, 20, 40, 0.55));
+  border: 1px solid rgba(92, 241, 255, 0.2);
+  box-shadow: 0 36px 90px rgba(0, 0, 0, 0.5);
+}
+
+.admin-header p {
+  color: var(--muted);
+  margin: 0.5rem 0 0;
+}
+
+.admin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.admin-card {
+  padding: 1.5rem;
+  border-radius: 1.8rem;
+  background: rgba(12, 20, 40, 0.7);
+  border: 1px solid rgba(92, 241, 255, 0.2);
+  display: grid;
+  gap: 1rem;
+}
+
+.toggles {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.toggle-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(12, 20, 40, 0.65);
+  border: 1px solid rgba(92, 241, 255, 0.15);
+}
+
+.toggle-item label {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.toggle-item span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.switch {
+  position: relative;
+  width: 52px;
+  height: 28px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: rgba(92, 241, 255, 0.2);
+  border-radius: 999px;
+  transition: background 0.3s ease;
+}
+
+.slider::before {
+  content: "";
+  position: absolute;
+  height: 20px;
+  width: 20px;
+  left: 4px;
+  top: 4px;
+  border-radius: 50%;
+  background: linear-gradient(120deg, #5cf1ff, #d67bff);
+  transition: transform 0.3s ease;
+}
+
+input:checked + .slider {
+  background: rgba(92, 241, 255, 0.4);
+}
+
+input:checked + .slider::before {
+  transform: translateX(24px);
+}
+
+.payment-integration {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(12, 20, 40, 0.6);
+  border: 1px dashed rgba(92, 241, 255, 0.3);
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 960px) {
+  .site-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  nav {
+    order: 3;
+    width: 100%;
+    justify-content: center;
+  }
+
+  .auth-actions {
+    order: 2;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero {
+    border-radius: 1.5rem;
+    padding: 1.5rem;
+  }
+
+  .cart-drawer.open {
+    transform: translateX(-100%);
+  }
+
+  .order-footer {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+.ripple {
+  position: fixed;
+  width: 220px;
+  height: 220px;
+  margin-left: -110px;
+  margin-top: -110px;
+  pointer-events: none;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(92, 241, 255, 0.25), rgba(12, 20, 40, 0));
+  animation: ripple 0.8s ease-out;
+  mix-blend-mode: screen;
+  z-index: 999;
+}
+
+@keyframes ripple {
+  from {
+    transform: scale(0.3);
+    opacity: 0.6;
+  }
+  to {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+
+body.no-wave .ripple {
+  display: none;
+}
+
+body.no-glow .product-card .glow {
+  display: none;
+}
+
+body.no-glow .product-card:hover {
+  box-shadow: 0 16px 40px rgba(92, 241, 255, 0.15);
+}
+
+.hologram-off .product-card {
+  background: rgba(12, 20, 40, 0.65);
+  box-shadow: none;
+  border-color: rgba(92, 241, 255, 0.1);
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,751 @@
+const API_BASE = (() => {
+  if (window.NOVAWAVE_API) return `${window.NOVAWAVE_API.replace(/\/$/, "")}`;
+  if (window.location.origin.startsWith("http")) {
+    return `${window.location.origin}/api`;
+  }
+  return "http://localhost:8000/api";
+})();
+
+const STORAGE_TOKEN = "novaWaveToken";
+const STORAGE_CART = "novaWaveCart";
+
+const cartDrawer = document.getElementById("cart-drawer");
+const cartBtn = document.getElementById("cart-btn");
+const closeCartBtn = document.getElementById("close-cart");
+const cartItemsEl = document.getElementById("cart-items");
+const cartSubtotalEl = document.getElementById("cart-subtotal");
+const cartTotalEl = document.getElementById("cart-total");
+const productGrid = document.getElementById("product-grid");
+const productCardTemplate = document.getElementById("product-card-template");
+const cartItemTemplate = document.getElementById("cart-item-template");
+const orderTimeline = document.getElementById("order-timeline");
+const orderTemplate = document.getElementById("order-entry-template");
+const categoryGrid = document.getElementById("category-grid");
+const sortSelect = document.getElementById("sort-select");
+const searchInput = document.getElementById("search-input");
+const navButtons = document.querySelectorAll(".nav-btn");
+const views = document.querySelectorAll(".view");
+const loginBtn = document.getElementById("login-btn");
+const registerBtn = document.getElementById("register-btn");
+const logoutBtn = document.getElementById("logout-btn");
+const userPill = document.getElementById("user-pill");
+const userNameEl = document.getElementById("user-name");
+const adminNavBtn = document.getElementById("admin-nav");
+const authModal = document.getElementById("auth-modal");
+const authForm = document.getElementById("auth-form");
+const authTitle = document.getElementById("auth-title");
+const authEmail = document.getElementById("auth-email");
+const authPassword = document.getElementById("auth-password");
+const authName = document.getElementById("auth-name");
+const authAdminKey = document.getElementById("auth-admin-key");
+const authMessage = document.getElementById("auth-message");
+const registerOnly = document.getElementById("register-only");
+const productForm = document.getElementById("product-form");
+const productIdInput = document.getElementById("product-id");
+const productNameInput = document.getElementById("product-name");
+const productCategoryInput = document.getElementById("product-category");
+const productPriceInput = document.getElementById("product-price");
+const productDescriptionInput = document.getElementById("product-description");
+const productImageInput = document.getElementById("product-image");
+const resetProductBtn = document.getElementById("reset-product");
+const featureTogglesEl = document.getElementById("feature-toggles");
+const paymentForm = document.getElementById("payment-form");
+const paymentStatusSelect = document.getElementById("payment-status");
+const paymentAnnouncementInput = document.getElementById("payment-announcement");
+const paymentIntegrationEl = document.getElementById("payment-integration");
+const checkoutBtn = document.getElementById("checkout-btn");
+const liveStatsEl = document.getElementById("live-stats");
+const orbitingCard = document.getElementById("orbiting-card");
+const heroScrollButtons = document.querySelectorAll("[data-scroll]");
+
+const state = {
+  user: null,
+  token: localStorage.getItem(STORAGE_TOKEN) || null,
+  products: [],
+  filteredProducts: [],
+  categories: [],
+  cart: loadCart(),
+  settings: {
+    features: {
+      hologramCards: true,
+      waveMotion: true,
+      glowHighlights: true,
+      autoRecommendations: true,
+    },
+    payment: {
+      status: "online",
+      announcement: "Thanh toán PayPal giảm 10% hôm nay!",
+    },
+  },
+  metrics: null,
+};
+
+function loadCart() {
+  try {
+    const raw = localStorage.getItem(STORAGE_CART);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((item) => typeof item.product_id === "number" && item.quantity > 0);
+    }
+  } catch (err) {
+    console.warn("Không thể đọc giỏ hàng", err);
+  }
+  return [];
+}
+
+function persistCart() {
+  localStorage.setItem(STORAGE_CART, JSON.stringify(state.cart));
+}
+
+function setToken(token) {
+  state.token = token;
+  if (token) {
+    localStorage.setItem(STORAGE_TOKEN, token);
+  } else {
+    localStorage.removeItem(STORAGE_TOKEN);
+  }
+}
+
+async function api(path, options = {}) {
+  const config = {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    ...options,
+  };
+  if (state.token) {
+    config.headers.Authorization = `Bearer ${state.token}`;
+  }
+  const response = await fetch(`${API_BASE}${path}`, config);
+  if (!response.ok) {
+    let detail = "Đã xảy ra lỗi";
+    try {
+      const payload = await response.json();
+      detail = payload.detail || JSON.stringify(payload);
+    } catch (err) {
+      detail = response.statusText;
+    }
+    throw new Error(detail);
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+function formatCurrency(value) {
+  return Number(value || 0).toLocaleString("vi-VN", {
+    style: "currency",
+    currency: "VND",
+    maximumFractionDigits: 0,
+  });
+}
+
+function formatDate(iso) {
+  return new Date(iso).toLocaleString("vi-VN", {
+    hour: "2-digit",
+    minute: "2-digit",
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+function setView(view) {
+  views.forEach((panel) => {
+    panel.classList.toggle("active", panel.id === view);
+  });
+  navButtons.forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.view === view);
+  });
+  if (view === "orders") {
+    refreshOrders();
+  }
+  if (view === "admin" && state.user?.role === "admin") {
+    refreshMetrics();
+  }
+}
+
+function updateUserUI() {
+  if (state.user) {
+    userPill.hidden = false;
+    userNameEl.textContent = state.user.name;
+    loginBtn.hidden = true;
+    registerBtn.hidden = true;
+    logoutBtn.hidden = false;
+    if (state.user.role === "admin") {
+      adminNavBtn.hidden = false;
+    } else {
+      adminNavBtn.hidden = true;
+    }
+  } else {
+    userPill.hidden = true;
+    loginBtn.hidden = false;
+    registerBtn.hidden = false;
+    logoutBtn.hidden = true;
+    adminNavBtn.hidden = true;
+  }
+}
+
+function updateCartBadge() {
+  const totalItems = state.cart.reduce((sum, item) => sum + item.quantity, 0);
+  cartBtn.setAttribute("data-count", totalItems);
+}
+
+function openCart() {
+  cartDrawer.classList.add("open");
+  renderCart();
+}
+
+function closeCart() {
+  cartDrawer.classList.remove("open");
+}
+
+function findProductById(id) {
+  return state.products.find((prod) => prod.id === id);
+}
+
+function addToCart(productId) {
+  const existing = state.cart.find((item) => item.product_id === productId);
+  if (existing) {
+    existing.quantity += 1;
+  } else {
+    state.cart.push({ product_id: productId, quantity: 1 });
+  }
+  persistCart();
+  updateCartBadge();
+  renderCart();
+}
+
+function updateCartQuantity(productId, delta) {
+  const entry = state.cart.find((item) => item.product_id === productId);
+  if (!entry) return;
+  entry.quantity += delta;
+  if (entry.quantity <= 0) {
+    state.cart = state.cart.filter((item) => item.product_id !== productId);
+  }
+  persistCart();
+  updateCartBadge();
+  renderCart();
+}
+
+function renderCart() {
+  cartItemsEl.innerHTML = "";
+  let subtotal = 0;
+  state.cart.forEach((entry) => {
+    const product = findProductById(entry.product_id);
+    if (!product) return;
+    subtotal += product.price * entry.quantity;
+    const node = cartItemTemplate.content.cloneNode(true);
+    node.querySelector(".item-title").textContent = product.name;
+    node.querySelector(".item-meta").textContent = `${product.category} • ${formatCurrency(product.price)}`;
+    node.querySelector(".item-quantity").textContent = entry.quantity;
+    node.querySelector(".item-price").textContent = formatCurrency(product.price * entry.quantity);
+    node.querySelector(".decrease").addEventListener("click", () => updateCartQuantity(product.id, -1));
+    node.querySelector(".increase").addEventListener("click", () => updateCartQuantity(product.id, 1));
+    cartItemsEl.appendChild(node);
+  });
+  cartSubtotalEl.textContent = formatCurrency(subtotal);
+  cartTotalEl.textContent = formatCurrency(subtotal);
+}
+
+function applyFilters() {
+  const term = searchInput.value.trim().toLowerCase();
+  const sort = sortSelect.value;
+  let products = [...state.products];
+  if (term) {
+    products = products.filter(
+      (product) =>
+        product.name.toLowerCase().includes(term) ||
+        product.category.toLowerCase().includes(term) ||
+        product.description.toLowerCase().includes(term)
+    );
+  }
+  switch (sort) {
+    case "price-asc":
+      products.sort((a, b) => a.price - b.price);
+      break;
+    case "price-desc":
+      products.sort((a, b) => b.price - a.price);
+      break;
+    case "newest":
+      products.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+      break;
+    default:
+      products.sort((a, b) => b.popularity - a.popularity);
+      break;
+  }
+  state.filteredProducts = products;
+  renderProducts();
+}
+
+function renderProducts() {
+  productGrid.innerHTML = "";
+  state.filteredProducts.forEach((product) => {
+    const node = productCardTemplate.content.cloneNode(true);
+    const card = node.querySelector(".product-card");
+    if (!state.settings.features.hologramCards) {
+      card.classList.add("no-hologram");
+    }
+    node.querySelector(".product-image").src = product.image_url;
+    node.querySelector(".product-image").alt = product.name;
+    node.querySelector(".product-title").textContent = product.name;
+    node.querySelector(".product-description").textContent = product.description;
+    node.querySelector(".product-category").textContent = product.category;
+    node.querySelector(".product-price").textContent = formatCurrency(product.price);
+    node.querySelector(".add-cart-btn").addEventListener("click", () => addToCart(product.id));
+    const editBtn = node.querySelector(".edit-btn");
+    if (state.user?.role === "admin") {
+      editBtn.hidden = false;
+      editBtn.addEventListener("click", () => populateProductForm(product));
+    }
+    productGrid.appendChild(node);
+  });
+  updateOrbitingCard();
+}
+
+function updateOrbitingCard() {
+  if (!orbitingCard) return;
+  const product = state.filteredProducts[0];
+  if (!product) {
+    orbitingCard.innerHTML = "";
+    return;
+  }
+  orbitingCard.innerHTML = `
+    <div class="orbit-title">${product.name}</div>
+    <div class="orbit-price">${formatCurrency(product.price)}</div>
+  `;
+}
+
+function renderCategories() {
+  categoryGrid.innerHTML = "";
+  state.categories.forEach((entry) => {
+    const div = document.createElement("div");
+    div.className = "category-card";
+    div.innerHTML = `
+      <span class="category-name">${entry.category}</span>
+      <span class="category-count">${entry.total} sản phẩm</span>
+    `;
+    div.addEventListener("click", () => {
+      searchInput.value = entry.category;
+      applyFilters();
+      window.scrollTo({ top: document.getElementById("featured").offsetTop - 80, behavior: "smooth" });
+    });
+    categoryGrid.appendChild(div);
+  });
+}
+
+function renderOrders(orders) {
+  orderTimeline.innerHTML = "";
+  orders.forEach((order) => {
+    const node = orderTemplate.content.cloneNode(true);
+    node.querySelector(".order-id").textContent = `Đơn #${order.id}`;
+    node.querySelector(".order-date").textContent = formatDate(order.created_at);
+    const body = node.querySelector(".order-body");
+    order.items.forEach((item) => {
+      const line = document.createElement("p");
+      line.textContent = `${item.name} × ${item.quantity}`;
+      body.appendChild(line);
+    });
+    if (order.customer_name) {
+      const badge = document.createElement("span");
+      badge.className = "order-customer";
+      badge.textContent = `Khách hàng: ${order.customer_name}`;
+      body.appendChild(badge);
+    }
+    node.querySelector(".order-total").textContent = formatCurrency(order.total);
+    node.querySelector(".order-method").textContent = order.payment_method;
+    node.querySelector(".order-status").textContent = order.status;
+    orderTimeline.appendChild(node);
+  });
+}
+
+function renderFeatureToggles() {
+  if (!featureTogglesEl) return;
+  featureTogglesEl.innerHTML = "";
+  Object.entries(state.settings.features).forEach(([key, value]) => {
+    const label = document.createElement("label");
+    label.className = "toggle";
+    label.innerHTML = `
+      <span>${featureLabel(key)}</span>
+      <input type="checkbox" ${value ? "checked" : ""} />
+    `;
+    const input = label.querySelector("input");
+    if (state.user?.role !== "admin") {
+      input.disabled = true;
+    }
+    input.addEventListener("change", async () => {
+      if (state.user?.role !== "admin") {
+        input.checked = !input.checked;
+        return;
+      }
+      try {
+        const toggles = { ...state.settings.features, [key]: input.checked };
+        await api("/settings/features", {
+          method: "PUT",
+          body: JSON.stringify({ toggles }),
+        });
+        state.settings.features = toggles;
+        applyFilters();
+      } catch (err) {
+        input.checked = !input.checked;
+        showMessage(err.message);
+      }
+    });
+    featureTogglesEl.appendChild(label);
+  });
+}
+
+function featureLabel(key) {
+  switch (key) {
+    case "hologramCards":
+      return "Thẻ hologram";
+    case "waveMotion":
+      return "Hiệu ứng sóng";
+    case "glowHighlights":
+      return "Viền phát sáng";
+    case "autoRecommendations":
+      return "Gợi ý tự động";
+    default:
+      return key;
+  }
+}
+
+function updatePaymentPanel() {
+  if (!paymentIntegrationEl) return;
+  paymentStatusSelect.value = state.settings.payment.status;
+  paymentAnnouncementInput.value = state.settings.payment.announcement;
+  paymentIntegrationEl.innerHTML = `
+    <div class="payment-status ${state.settings.payment.status}">
+      <strong>Trạng thái:</strong> ${
+        state.settings.payment.status === "online" ? "Đang hoạt động" : "Bảo trì"
+      }
+    </div>
+    <p>${state.settings.payment.announcement}</p>
+  `;
+}
+
+function showMessage(message, type = "error") {
+  authMessage.textContent = message;
+  authMessage.dataset.type = type;
+  authMessage.hidden = false;
+  setTimeout(() => {
+    authMessage.textContent = "";
+    authMessage.hidden = true;
+  }, 4000);
+}
+
+async function bootstrap() {
+  updateUserUI();
+  updateCartBadge();
+  if (state.token) {
+    try {
+      const { user } = await api("/auth/me");
+      state.user = user;
+    } catch (err) {
+      setToken(null);
+    }
+  }
+  updateUserUI();
+  await Promise.all([refreshProducts(), refreshCategories(), refreshSettings()]);
+  if (state.user?.role === "admin") {
+    refreshMetrics();
+  }
+  applyFilters();
+  if (state.user) {
+    refreshOrders();
+  }
+  bindEvents();
+  startLiveStats();
+}
+
+async function refreshProducts() {
+  const data = await api("/products");
+  state.products = data.products;
+  applyFilters();
+}
+
+async function refreshCategories() {
+  const data = await api("/categories");
+  state.categories = data.categories;
+  renderCategories();
+}
+
+async function refreshSettings() {
+  try {
+    const settings = await api("/settings");
+    state.settings = {
+      ...state.settings,
+      ...settings,
+    };
+    renderFeatureToggles();
+    updatePaymentPanel();
+  } catch (err) {
+    console.warn("Không thể tải cấu hình", err);
+  }
+}
+
+async function refreshOrders() {
+  if (!state.user) return;
+  try {
+    const data = await api("/orders");
+    renderOrders(data.orders);
+  } catch (err) {
+    showMessage(err.message);
+  }
+}
+
+async function refreshMetrics() {
+  if (state.user?.role !== "admin") return;
+  try {
+    state.metrics = await api("/dashboard/metrics");
+    updateLiveStats();
+  } catch (err) {
+    console.warn("Không thể tải metrics", err);
+  }
+}
+
+function bindEvents() {
+  sortSelect.addEventListener("change", applyFilters);
+  searchInput.addEventListener("input", () => {
+    window.requestAnimationFrame(applyFilters);
+  });
+  cartBtn.addEventListener("click", openCart);
+  closeCartBtn.addEventListener("click", closeCart);
+  checkoutBtn.addEventListener("click", handleCheckout);
+  navButtons.forEach((btn) => {
+    btn.addEventListener("click", () => setView(btn.dataset.view));
+  });
+  heroScrollButtons.forEach((btn) => {
+    const targetId = btn.dataset.scroll;
+    btn.addEventListener("click", () => {
+      const target = document.getElementById(targetId);
+      if (target) {
+        window.scrollTo({ top: target.offsetTop - 80, behavior: "smooth" });
+      }
+    });
+  });
+  loginBtn.addEventListener("click", () => openAuthModal(false));
+  registerBtn.addEventListener("click", () => openAuthModal(true));
+  logoutBtn.addEventListener("click", handleLogout);
+  authForm.addEventListener("submit", handleAuthSubmit);
+  resetProductBtn.addEventListener("click", (event) => {
+    event.preventDefault();
+    clearProductForm();
+  });
+  productForm.addEventListener("submit", handleProductSubmit);
+  paymentForm.addEventListener("submit", handlePaymentSubmit);
+}
+
+function openAuthModal(isRegister) {
+  authTitle.textContent = isRegister ? "Đăng ký" : "Đăng nhập";
+  registerOnly.style.display = isRegister ? "grid" : "none";
+  authForm.dataset.mode = isRegister ? "register" : "login";
+  authMessage.textContent = "";
+  authMessage.hidden = true;
+  authModal.showModal();
+}
+
+async function handleAuthSubmit(event) {
+  event.preventDefault();
+  const payload = {
+    email: authEmail.value.trim(),
+    password: authPassword.value,
+  };
+  const isRegister = authForm.dataset.mode === "register";
+  try {
+    let data;
+    if (isRegister) {
+      data = await api("/auth/register", {
+        method: "POST",
+        body: JSON.stringify({
+          ...payload,
+          name: authName.value.trim(),
+          admin_key: authAdminKey.value.trim() || undefined,
+        }),
+      });
+    } else {
+      data = await api("/auth/login", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    }
+    state.user = data.user;
+    setToken(data.token);
+    updateUserUI();
+    authModal.close();
+    authForm.reset();
+    await refreshSettings();
+    refreshOrders();
+    if (state.user.role === "admin") {
+      refreshMetrics();
+    }
+  } catch (err) {
+    showMessage(err.message);
+  }
+}
+
+async function handleLogout() {
+  try {
+    await api("/auth/logout", { method: "POST" });
+  } catch (err) {
+    console.warn("Không thể đăng xuất", err);
+  }
+  state.user = null;
+  setToken(null);
+  updateUserUI();
+  renderFeatureToggles();
+  setView("market");
+}
+
+function populateProductForm(product) {
+  setView("admin");
+  productIdInput.value = product.id;
+  productNameInput.value = product.name;
+  productCategoryInput.value = product.category;
+  productPriceInput.value = product.price;
+  productDescriptionInput.value = product.description;
+  productImageInput.value = product.image_url;
+}
+
+function clearProductForm() {
+  productIdInput.value = "";
+  productForm.reset();
+}
+
+async function handleProductSubmit(event) {
+  event.preventDefault();
+  if (state.user?.role !== "admin") {
+    showMessage("Bạn không có quyền quản trị");
+    return;
+  }
+  const payload = {
+    name: productNameInput.value.trim(),
+    category: productCategoryInput.value.trim(),
+    price: Number(productPriceInput.value),
+    description: productDescriptionInput.value.trim(),
+    image_url: productImageInput.value.trim(),
+    popularity: 80,
+  };
+  try {
+    if (productIdInput.value) {
+      await api(`/products/${productIdInput.value}`, {
+        method: "PUT",
+        body: JSON.stringify(payload),
+      });
+    } else {
+      await api("/products", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    }
+    clearProductForm();
+    await refreshProducts();
+    await refreshCategories();
+  } catch (err) {
+    showMessage(err.message);
+  }
+}
+
+async function handlePaymentSubmit(event) {
+  event.preventDefault();
+  if (state.user?.role !== "admin") {
+    showMessage("Bạn không có quyền quản trị");
+    return;
+  }
+  try {
+    const payload = {
+      status: paymentStatusSelect.value,
+      announcement: paymentAnnouncementInput.value.trim(),
+    };
+    const { payment } = await api("/settings/payment", {
+      method: "PUT",
+      body: JSON.stringify(payload),
+    });
+    state.settings.payment = payment;
+    updatePaymentPanel();
+  } catch (err) {
+    showMessage(err.message);
+  }
+}
+
+async function handleCheckout() {
+  if (!state.user) {
+    openAuthModal(false);
+    showMessage("Bạn cần đăng nhập để thanh toán", "info");
+    return;
+  }
+  if (state.cart.length === 0) {
+    showMessage("Giỏ hàng đang trống", "info");
+    return;
+  }
+  const paymentMethod = document.querySelector('input[name="payment-method"]:checked').value;
+  try {
+    const body = {
+      items: state.cart.map((item) => ({
+        product_id: item.product_id,
+        quantity: item.quantity,
+      })),
+      payment_method: paymentMethod,
+    };
+    await api("/orders", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    state.cart = [];
+    persistCart();
+    updateCartBadge();
+    renderCart();
+    closeCart();
+    refreshOrders();
+  } catch (err) {
+    showMessage(err.message);
+  }
+}
+
+function startLiveStats() {
+  updateLiveStats();
+  setInterval(updateLiveStats, 6000);
+}
+
+function updateLiveStats() {
+  if (!liveStatsEl) return;
+  const metrics = state.metrics;
+  if (!metrics) {
+    const totalProducts = state.products.length;
+    const totalCategories = state.categories.length;
+    liveStatsEl.innerHTML = `
+      <div class="stat-chip">
+        <strong>${totalProducts}</strong>
+        <span>Sản phẩm đang sẵn sàng</span>
+      </div>
+      <div class="stat-chip">
+        <strong>${totalCategories}</strong>
+        <span>Danh mục linh hoạt</span>
+      </div>
+    `;
+    return;
+  }
+  liveStatsEl.innerHTML = `
+    <div class="stat-chip">
+      <strong>${metrics.users}</strong>
+      <span>Người dùng đã tham gia</span>
+    </div>
+    <div class="stat-chip">
+      <strong>${metrics.products}</strong>
+      <span>Sản phẩm đang hoạt động</span>
+    </div>
+    <div class="stat-chip">
+      <strong>${metrics.orders}</strong>
+      <span>Đơn hàng ghi nhận</span>
+    </div>
+    <div class="stat-chip">
+      <strong>${formatCurrency(metrics.revenue)}</strong>
+      <span>Doanh thu cục bộ</span>
+    </div>
+  `;
+}
+
+bootstrap().catch((err) => {
+  console.error("Không thể khởi tạo ứng dụng", err);
+});

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,601 @@
+import hashlib
+import json
+import secrets
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, EmailStr, Field
+
+DATABASE_PATH = "backend/novawave.db"
+ADMIN_ENROLL_KEY = "NEBULA"
+DEFAULT_SETTINGS = {
+    "features": {
+        "hologramCards": True,
+        "waveMotion": True,
+        "glowHighlights": True,
+        "autoRecommendations": True,
+    },
+    "payment": {
+        "status": "online",
+        "announcement": "Thanh toán PayPal giảm 10% hôm nay!",
+    },
+}
+
+
+def _dict_factory(cursor, row):
+    return {col[0]: row[idx] for idx, col in enumerate(cursor.description)}
+
+
+@contextmanager
+def get_connection():
+    conn = sqlite3.connect(DATABASE_PATH)
+    conn.row_factory = _dict_factory
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def init_db():
+    with get_connection() as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                email TEXT UNIQUE NOT NULL,
+                password_hash TEXT NOT NULL,
+                role TEXT NOT NULL DEFAULT 'user',
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS sessions (
+                token TEXT PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS products (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                category TEXT NOT NULL,
+                price INTEGER NOT NULL,
+                description TEXT NOT NULL,
+                image_url TEXT NOT NULL,
+                popularity INTEGER NOT NULL DEFAULT 50,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS orders (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                total INTEGER NOT NULL,
+                payment_method TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+            );
+
+            CREATE TABLE IF NOT EXISTS order_items (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                order_id INTEGER NOT NULL,
+                product_id INTEGER NOT NULL,
+                quantity INTEGER NOT NULL,
+                price INTEGER NOT NULL,
+                FOREIGN KEY(order_id) REFERENCES orders(id) ON DELETE CASCADE,
+                FOREIGN KEY(product_id) REFERENCES products(id)
+            );
+
+            CREATE TABLE IF NOT EXISTS settings (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            """
+        )
+
+        admin_exists = conn.execute(
+            "SELECT 1 FROM users WHERE role='admin' LIMIT 1"
+        ).fetchone()
+        if not admin_exists:
+            create_user(
+                conn,
+                name="Nova Admin",
+                email="admin@novawave.vn",
+                password="admin123",
+                role="admin",
+            )
+
+        product_count = conn.execute("SELECT COUNT(*) AS count FROM products").fetchone()[
+            "count"
+        ]
+        if product_count == 0:
+            seed_products(conn)
+
+        settings_rows = conn.execute(
+            "SELECT key FROM settings"
+        ).fetchall()
+        existing_keys = {row["key"] for row in settings_rows}
+        for key, value in DEFAULT_SETTINGS.items():
+            if key not in existing_keys:
+                conn.execute(
+                    "INSERT INTO settings (key, value) VALUES (?, ?)",
+                    (key, json.dumps(value)),
+                )
+
+
+def seed_products(conn: sqlite3.Connection):
+    now = datetime.utcnow().isoformat()
+    catalog = [
+        (
+            "AeroPulse Tai nghe AR",
+            "Công nghệ",
+            2599000,
+            "Tai nghe không dây phủ AR, cách âm chủ động và tương tác cảm biến chuyển động.",
+            "https://images.unsplash.com/photo-1546435770-a3e426bf472b?auto=format&fit=crop&w=800&q=80",
+            98,
+        ),
+        (
+            "LunaFibre Áo khoác phản quang",
+            "Thời trang",
+            1899000,
+            "Chất liệu nano giữ nhiệt, đổi màu theo ánh sáng và hiển thị thông báo thông minh.",
+            "https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=800&q=80",
+            88,
+        ),
+        (
+            "NebulaBoard Bàn phím hologram",
+            "Thiết bị",
+            3299000,
+            "Bàn phím cảm ứng không khung với hiệu ứng hologram và phản hồi haptic",
+            "https://images.unsplash.com/photo-1517059224940-d4af9eec41e5?auto=format&fit=crop&w=800&q=80",
+            95,
+        ),
+        (
+            "FluxStep Giày tự điều chỉnh",
+            "Thời trang",
+            1499000,
+            "Giày sneaker với đệm khí thông minh và cảm biến phân tích bước chân realtime.",
+            "https://images.unsplash.com/photo-1542293787938-4d2226df1672?auto=format&fit=crop&w=800&q=80",
+            82,
+        ),
+        (
+            "HelioBrew Máy pha cà phê AI",
+            "Gia dụng",
+            2799000,
+            "Pha chế theo khẩu vị cá nhân bằng phân tích hương vị và nhiệt độ chính xác.",
+            "https://images.unsplash.com/photo-1507914372361-74f3f90d4d1a?auto=format&fit=crop&w=800&q=80",
+            91,
+        ),
+    ]
+    conn.executemany(
+        """
+        INSERT INTO products (name, category, price, description, image_url, popularity, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        [(name, category, price, desc, image, pop, now) for name, category, price, desc, image, pop in catalog],
+    )
+
+
+def hash_password(password: str) -> str:
+    salt = secrets.token_hex(16)
+    digest = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
+    return f"{salt}${digest}"
+
+
+def verify_password(password: str, stored: str) -> bool:
+    try:
+        salt, digest = stored.split("$")
+    except ValueError:
+        return False
+    candidate = hashlib.sha256(f"{salt}:{password}".encode()).hexdigest()
+    return secrets.compare_digest(candidate, digest)
+
+
+def create_user(
+    conn: sqlite3.Connection,
+    *,
+    name: str,
+    email: str,
+    password: str,
+    role: str = "user",
+):
+    now = datetime.utcnow().isoformat()
+    conn.execute(
+        """
+        INSERT INTO users (name, email, password_hash, role, created_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (name, email.lower(), hash_password(password), role, now),
+    )
+
+
+def create_session(conn: sqlite3.Connection, user_id: int) -> str:
+    token = secrets.token_urlsafe(32)
+    now = datetime.utcnow().isoformat()
+    conn.execute(
+        "INSERT INTO sessions (token, user_id, created_at) VALUES (?, ?, ?)",
+        (token, user_id, now),
+    )
+    return token
+
+
+def load_settings(conn: sqlite3.Connection) -> Dict[str, dict]:
+    rows = conn.execute("SELECT key, value FROM settings").fetchall()
+    return {row["key"]: json.loads(row["value"]) for row in rows}
+
+
+def save_setting(conn: sqlite3.Connection, key: str, value: dict):
+    conn.execute(
+        "INSERT INTO settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+        (key, json.dumps(value)),
+    )
+
+
+class ProductPayload(BaseModel):
+    name: str
+    category: str
+    price: int = Field(gt=0)
+    description: str
+    image_url: str
+    popularity: int = Field(ge=0, le=100, default=50)
+
+
+class RegisterPayload(BaseModel):
+    name: str
+    email: EmailStr
+    password: str
+    admin_key: Optional[str] = None
+
+
+class LoginPayload(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class OrderItemPayload(BaseModel):
+    product_id: int
+    quantity: int = Field(gt=0)
+
+
+class OrderPayload(BaseModel):
+    items: List[OrderItemPayload]
+    payment_method: str
+
+
+class FeatureTogglePayload(BaseModel):
+    toggles: Dict[str, bool]
+
+
+class PaymentConfigPayload(BaseModel):
+    status: str
+    announcement: str
+
+
+app = FastAPI(title="NovaWave API", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"]
+    ,
+    allow_headers=["*"],
+)
+
+
+@app.on_event("startup")
+def startup_event():
+    init_db()
+
+
+async def get_current_session(authorization: Optional[str] = Header(None)):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Thiếu token")
+    token = authorization.split()[1]
+    with get_connection() as conn:
+        record = conn.execute(
+            """
+            SELECT sessions.token, users.id, users.name, users.email, users.role
+            FROM sessions
+            JOIN users ON users.id = sessions.user_id
+            WHERE sessions.token = ?
+            """,
+            (token,),
+        ).fetchone()
+    if not record:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token không hợp lệ")
+    return record
+
+
+async def get_current_user(session=Depends(get_current_session)):
+    return session
+
+
+async def get_admin_user(user=Depends(get_current_user)):
+    if user["role"] != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Yêu cầu quyền admin")
+    return user
+
+
+@app.post("/api/auth/register")
+def register(payload: RegisterPayload):
+    with get_connection() as conn:
+        existing = conn.execute(
+            "SELECT id FROM users WHERE email = ?",
+            (payload.email.lower(),),
+        ).fetchone()
+        if existing:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email đã tồn tại")
+
+        role = "admin" if payload.admin_key == ADMIN_ENROLL_KEY else "user"
+        if payload.admin_key and role != "admin":
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Mã admin không chính xác")
+
+        create_user(
+            conn,
+            name=payload.name,
+            email=payload.email,
+            password=payload.password,
+            role=role,
+        )
+        user_row = conn.execute(
+            "SELECT id, name, email, role FROM users WHERE email = ?",
+            (payload.email.lower(),),
+        ).fetchone()
+        token = create_session(conn, user_row["id"])
+        return {"token": token, "user": user_row}
+
+
+@app.post("/api/auth/login")
+def login(payload: LoginPayload):
+    with get_connection() as conn:
+        user = conn.execute(
+            "SELECT id, name, email, role, password_hash FROM users WHERE email = ?",
+            (payload.email.lower(),),
+        ).fetchone()
+        if not user or not verify_password(payload.password, user["password_hash"]):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Thông tin đăng nhập sai")
+        token = create_session(conn, user["id"])
+        user.pop("password_hash", None)
+        return {"token": token, "user": user}
+
+
+@app.get("/api/auth/me")
+def auth_me(user=Depends(get_current_user)):
+    return {"user": user}
+
+
+@app.post("/api/auth/logout")
+def logout(user=Depends(get_current_session)):
+    token = user["token"]
+    with get_connection() as conn:
+        conn.execute("DELETE FROM sessions WHERE token = ?", (token,))
+    return {"success": True}
+
+
+@app.get("/api/products")
+def list_products():
+    with get_connection() as conn:
+        products = conn.execute(
+            "SELECT id, name, category, price, description, image_url, popularity, created_at FROM products ORDER BY created_at DESC"
+        ).fetchall()
+    return {"products": products}
+
+
+@app.post("/api/products", status_code=status.HTTP_201_CREATED)
+def create_product(payload: ProductPayload, admin=Depends(get_admin_user)):
+    now = datetime.utcnow().isoformat()
+    with get_connection() as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO products (name, category, price, description, image_url, popularity, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                payload.name,
+                payload.category,
+                payload.price,
+                payload.description,
+                payload.image_url,
+                payload.popularity,
+                now,
+            ),
+        )
+        product_id = cursor.lastrowid
+        product = conn.execute(
+            "SELECT id, name, category, price, description, image_url, popularity, created_at FROM products WHERE id = ?",
+            (product_id,),
+        ).fetchone()
+    return product
+
+
+@app.put("/api/products/{product_id}")
+def update_product(product_id: int, payload: ProductPayload, admin=Depends(get_admin_user)):
+    with get_connection() as conn:
+        existing = conn.execute(
+            "SELECT id FROM products WHERE id = ?",
+            (product_id,),
+        ).fetchone()
+        if not existing:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Không tìm thấy sản phẩm")
+        conn.execute(
+            """
+            UPDATE products
+            SET name = ?, category = ?, price = ?, description = ?, image_url = ?, popularity = ?
+            WHERE id = ?
+            """,
+            (
+                payload.name,
+                payload.category,
+                payload.price,
+                payload.description,
+                payload.image_url,
+                payload.popularity,
+                product_id,
+            ),
+        )
+        product = conn.execute(
+            "SELECT id, name, category, price, description, image_url, popularity, created_at FROM products WHERE id = ?",
+            (product_id,),
+        ).fetchone()
+    return product
+
+
+@app.delete("/api/products/{product_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_product(product_id: int, admin=Depends(get_admin_user)):
+    with get_connection() as conn:
+        conn.execute("DELETE FROM products WHERE id = ?", (product_id,))
+    return None
+
+
+@app.get("/api/categories")
+def list_categories():
+    with get_connection() as conn:
+        rows = conn.execute(
+            "SELECT category, COUNT(*) AS total FROM products GROUP BY category ORDER BY category"
+        ).fetchall()
+    return {"categories": rows}
+
+
+@app.get("/api/settings")
+def get_settings():
+    with get_connection() as conn:
+        settings = load_settings(conn)
+    return settings
+
+
+@app.put("/api/settings/features")
+def update_features(payload: FeatureTogglePayload, admin=Depends(get_admin_user)):
+    with get_connection() as conn:
+        save_setting(conn, "features", payload.toggles)
+        features = load_settings(conn)["features"]
+    return {"features": features}
+
+
+@app.put("/api/settings/payment")
+def update_payment(payload: PaymentConfigPayload, admin=Depends(get_admin_user)):
+    with get_connection() as conn:
+        save_setting(conn, "payment", payload.dict())
+        payment = load_settings(conn)["payment"]
+    return {"payment": payment}
+
+
+@app.get("/api/orders")
+def list_orders(user=Depends(get_current_user)):
+    with get_connection() as conn:
+        if user["role"] == "admin":
+            orders = conn.execute(
+                "SELECT o.id, o.total, o.payment_method, o.status, o.created_at, u.name AS customer_name FROM orders o JOIN users u ON u.id = o.user_id ORDER BY o.created_at DESC"
+            ).fetchall()
+        else:
+            orders = conn.execute(
+                "SELECT id, total, payment_method, status, created_at FROM orders WHERE user_id = ? ORDER BY created_at DESC",
+                (user["id"],),
+            ).fetchall()
+        order_ids = [o["id"] for o in orders]
+        items_map = {}
+        if order_ids:
+            placeholders = ",".join(["?"] * len(order_ids))
+            rows = conn.execute(
+                f"SELECT oi.order_id, oi.quantity, oi.price, p.name FROM order_items oi JOIN products p ON p.id = oi.product_id WHERE oi.order_id IN ({placeholders})",
+                order_ids,
+            ).fetchall()
+            for row in rows:
+                items_map.setdefault(row["order_id"], []).append(row)
+    for order in orders:
+        order["items"] = items_map.get(order["id"], [])
+    return {"orders": orders}
+
+
+@app.post("/api/orders", status_code=status.HTTP_201_CREATED)
+def create_order(payload: OrderPayload, user=Depends(get_current_user)):
+    if not payload.items:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Giỏ hàng trống")
+    with get_connection() as conn:
+        product_ids = [item.product_id for item in payload.items]
+        placeholders = ",".join(["?"] * len(product_ids))
+        db_products = conn.execute(
+            f"SELECT id, price FROM products WHERE id IN ({placeholders})",
+            product_ids,
+        ).fetchall()
+        price_map = {prod["id"]: prod["price"] for prod in db_products}
+        missing = [pid for pid in product_ids if pid not in price_map]
+        if missing:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Sản phẩm không hợp lệ: {missing}")
+        total = sum(price_map[item.product_id] * item.quantity for item in payload.items)
+        now = datetime.utcnow().isoformat()
+        cursor = conn.execute(
+            """
+            INSERT INTO orders (user_id, total, payment_method, status, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                user["id"],
+                total,
+                payload.payment_method,
+                "processing",
+                now,
+            ),
+        )
+        order_id = cursor.lastrowid
+        conn.executemany(
+            """
+            INSERT INTO order_items (order_id, product_id, quantity, price)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                (
+                    order_id,
+                    item.product_id,
+                    item.quantity,
+                    price_map[item.product_id],
+                )
+                for item in payload.items
+            ],
+        )
+        order = conn.execute(
+            "SELECT id, total, payment_method, status, created_at FROM orders WHERE id = ?",
+            (order_id,),
+        ).fetchone()
+        items = conn.execute(
+            """
+            SELECT oi.quantity, oi.price, p.name
+            FROM order_items oi
+            JOIN products p ON p.id = oi.product_id
+            WHERE oi.order_id = ?
+            """,
+            (order_id,),
+        ).fetchall()
+        order["items"] = items
+    return order
+
+
+@app.get("/api/dashboard/metrics")
+def dashboard_metrics(user=Depends(get_admin_user)):
+    with get_connection() as conn:
+        total_users = conn.execute("SELECT COUNT(*) AS total FROM users").fetchone()["total"]
+        total_products = conn.execute("SELECT COUNT(*) AS total FROM products").fetchone()["total"]
+        total_orders_row = conn.execute(
+            "SELECT COUNT(*) AS total, COALESCE(SUM(total), 0) AS revenue FROM orders"
+        ).fetchone()
+        last_orders = conn.execute(
+            "SELECT id, total, payment_method, status, created_at FROM orders ORDER BY created_at DESC LIMIT 5"
+        ).fetchall()
+    return {
+        "users": total_users,
+        "products": total_products,
+        "orders": total_orders_row["total"],
+        "revenue": total_orders_row["revenue"],
+        "recentOrders": last_orders,
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("backend.app:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+email-validator==2.1.1

--- a/index.html
+++ b/index.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>NovaWave Commerce</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;700&family=Rubik:wght@300;400;500;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <div class="neon-grid"></div>
+  <header class="site-header">
+    <div class="logo">
+      <span class="logo-icon">⚡</span>
+      <div>
+        <h1>NovaWave</h1>
+        <p>Thương mại điện tử thời đại ảo</p>
+      </div>
+    </div>
+    <nav>
+      <button class="nav-btn" data-view="market">Sản phẩm</button>
+      <button class="nav-btn" data-view="orders">Đơn hàng</button>
+      <button class="nav-btn" data-view="admin" id="admin-nav" hidden>Trung tâm Admin</button>
+    </nav>
+    <div class="auth-actions">
+      <div id="user-pill" class="user-pill" hidden>
+        <span id="user-name"></span>
+        <button id="logout-btn" class="ghost-btn">Đăng xuất</button>
+      </div>
+      <button id="login-btn" class="primary-btn">Đăng nhập</button>
+      <button id="register-btn" class="ghost-btn">Đăng ký</button>
+      <button id="cart-btn" class="cart-btn" data-count="0">
+        <span>Giỏ hàng</span>
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+          <path d="M7 4h-2l-1 2v2h2l3.6 7.59-1.35 2.44c-.38.68-.09 1.52.59 1.9.21.12.44.17.66.17h10v-2h-9.42l.93-1.68h7.84c.75 0 1.41-.52 1.58-1.24l1.8-8h-16.43l-.72-2zm0 16c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm10 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+        </svg>
+      </button>
+    </div>
+  </header>
+
+  <main>
+    <section id="market" class="view active">
+      <div class="hero">
+        <div class="hero-content">
+          <h2>Trung tâm mua sắm vũ trụ</h2>
+          <p>Đắm chìm trong thế giới sản phẩm công nghệ, thời trang và lối sống với trải nghiệm chuyển động mượt mà như làn sóng ánh sáng.</p>
+          <div class="hero-actions">
+            <button class="primary-btn" data-scroll="featured">Khám phá ngay</button>
+            <button class="ghost-btn" data-scroll="categories">Danh mục nổi bật</button>
+          </div>
+          <div class="live-stats" id="live-stats"></div>
+        </div>
+        <div class="hero-visual">
+          <div class="sphere"></div>
+          <div class="ring"></div>
+          <div class="orbiting-card" id="orbiting-card"></div>
+        </div>
+      </div>
+
+      <section id="categories" class="categories">
+        <h3 class="section-title">Danh mục tương lai</h3>
+        <div class="category-grid" id="category-grid"></div>
+      </section>
+
+      <section id="featured" class="products">
+        <div class="section-heading">
+          <h3 class="section-title">Bộ sưu tập đặc sắc</h3>
+          <div class="filters">
+            <select id="sort-select">
+              <option value="popularity">Phổ biến</option>
+              <option value="price-asc">Giá tăng dần</option>
+              <option value="price-desc">Giá giảm dần</option>
+              <option value="newest">Mới nhất</option>
+            </select>
+            <input type="search" id="search-input" placeholder="Tìm kiếm sản phẩm..." />
+          </div>
+        </div>
+        <div class="product-grid" id="product-grid"></div>
+      </section>
+    </section>
+
+    <section id="orders" class="view">
+      <div class="orders-wrapper">
+        <h3 class="section-title">Lịch sử giao dịch</h3>
+        <div id="order-timeline" class="order-timeline"></div>
+      </div>
+    </section>
+
+    <section id="admin" class="view">
+      <div class="admin-panel">
+        <div class="admin-header">
+          <h3>Điều khiển NovaWave</h3>
+          <p>Quản trị viên có thể chỉnh sửa, thêm bớt chức năng trực tiếp trên giao diện.</p>
+        </div>
+        <div class="admin-grid">
+          <div class="admin-card">
+            <h4>Quản lý sản phẩm</h4>
+            <form id="product-form" class="stack">
+              <input type="hidden" id="product-id" />
+              <label>Tên sản phẩm
+                <input type="text" id="product-name" required />
+              </label>
+              <label>Danh mục
+                <input type="text" id="product-category" required />
+              </label>
+              <label>Giá (VND)
+                <input type="number" id="product-price" min="0" step="1000" required />
+              </label>
+              <label>Điểm nổi bật
+                <textarea id="product-description" rows="3" required></textarea>
+              </label>
+              <label>Hình ảnh (URL)
+                <input type="url" id="product-image" placeholder="https://..." required />
+              </label>
+              <div class="form-actions">
+                <button type="submit" class="primary-btn">Lưu sản phẩm</button>
+                <button type="button" id="reset-product" class="ghost-btn">Làm mới</button>
+              </div>
+            </form>
+          </div>
+
+          <div class="admin-card">
+            <h4>Điều chỉnh trải nghiệm</h4>
+            <div class="toggles" id="feature-toggles"></div>
+          </div>
+
+          <div class="admin-card">
+            <h4>Thanh toán & liên kết</h4>
+            <form id="payment-form" class="stack">
+              <label>Trạng thái hệ thống thanh toán
+                <select id="payment-status">
+                  <option value="online">Đang hoạt động</option>
+                  <option value="maintenance">Bảo trì</option>
+                </select>
+              </label>
+              <label>Tin nhắn nổi bật
+                <input type="text" id="payment-announcement" placeholder="Ví dụ: Giảm 10% cho thanh toán PayPal" />
+              </label>
+              <button type="submit" class="primary-btn">Cập nhật</button>
+            </form>
+            <div id="payment-integration" class="payment-integration"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div id="cart-drawer" class="cart-drawer">
+    <div class="cart-header">
+      <h3>Giỏ hàng NovaWave</h3>
+      <button id="close-cart" class="ghost-btn">Đóng</button>
+    </div>
+    <div id="cart-items" class="cart-items"></div>
+    <div class="cart-summary">
+      <div class="summary-line">
+        <span>Tạm tính</span>
+        <strong id="cart-subtotal">0₫</strong>
+      </div>
+      <div class="summary-line">
+        <span>Phí vận chuyển</span>
+        <strong id="cart-shipping">Miễn phí</strong>
+      </div>
+      <div class="summary-line total">
+        <span>Tổng cộng</span>
+        <strong id="cart-total">0₫</strong>
+      </div>
+      <div class="payment-options">
+        <h4>Phương thức thanh toán</h4>
+        <div class="payment-grid">
+          <label><input type="radio" name="payment-method" value="PayPal" checked /> PayPal</label>
+          <label><input type="radio" name="payment-method" value="Visa" /> Visa / Mastercard</label>
+          <label><input type="radio" name="payment-method" value="Chuyển khoản" /> Chuyển khoản ngân hàng</label>
+          <label><input type="radio" name="payment-method" value="Tiền mặt" /> Tiền mặt khi nhận hàng</label>
+        </div>
+      </div>
+      <button id="checkout-btn" class="primary-btn">Thanh toán</button>
+      <p class="security-note">Mọi dữ liệu được mã hóa và lưu trữ cục bộ trong thiết bị của bạn.</p>
+    </div>
+  </div>
+
+  <dialog id="auth-modal" class="auth-modal">
+    <form method="dialog" class="auth-shell" id="auth-form">
+      <header>
+        <h3 id="auth-title">Đăng nhập</h3>
+        <button value="cancel" class="ghost-btn">✕</button>
+      </header>
+      <div class="stack">
+        <label>Email
+          <input type="email" id="auth-email" required />
+        </label>
+        <label>Mật khẩu
+          <input type="password" id="auth-password" required />
+        </label>
+        <div id="register-only" class="register-only">
+          <label>Họ và tên
+            <input type="text" id="auth-name" />
+          </label>
+          <label>Mã quyền Admin (tùy chọn)
+            <input type="text" id="auth-admin-key" placeholder="Nhập NEBULA để đăng ký admin" />
+          </label>
+        </div>
+      </div>
+      <footer>
+        <button type="submit" class="primary-btn" id="auth-submit">Tiếp tục</button>
+      </footer>
+      <p id="auth-message" class="auth-message" role="alert"></p>
+    </form>
+  </dialog>
+
+  <template id="product-card-template">
+    <article class="product-card">
+      <div class="glow"></div>
+      <img class="product-image" alt="" />
+      <div class="product-body">
+        <h4 class="product-title"></h4>
+        <p class="product-description"></p>
+        <div class="product-meta">
+          <span class="product-category"></span>
+          <strong class="product-price"></strong>
+        </div>
+      </div>
+      <div class="product-actions">
+        <button class="ghost-btn edit-btn" hidden>Chỉnh sửa</button>
+        <button class="primary-btn add-cart-btn">Thêm vào giỏ</button>
+      </div>
+    </article>
+  </template>
+
+  <template id="cart-item-template">
+    <div class="cart-item">
+      <div class="item-info">
+        <h4 class="item-title"></h4>
+        <p class="item-meta"></p>
+      </div>
+      <div class="item-controls">
+        <button class="ghost-btn decrease">-</button>
+        <span class="item-quantity"></span>
+        <button class="ghost-btn increase">+</button>
+      </div>
+      <div class="item-price"></div>
+    </div>
+  </template>
+
+  <template id="order-entry-template">
+    <div class="order-entry">
+      <div class="order-header">
+        <h4 class="order-id"></h4>
+        <span class="order-date"></span>
+      </div>
+      <div class="order-body"></div>
+      <div class="order-footer">
+        <span class="order-total"></span>
+        <span class="order-method"></span>
+        <span class="order-status"></span>
+      </div>
+    </div>
+  </template>
+
+  <script src="assets/js/app.js" type="module"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce a FastAPI backend with SQLite storage for users, products, orders, and configuration endpoints
- update the NovaWave frontend to call the new API for authentication, catalog management, checkout, and admin settings
- document setup instructions for running the backend and static frontend together

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e5f2542b6483228724afaaa7cef809